### PR TITLE
Fix BadProviderError when using class providers in Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,12 @@ instance providers and class providers). The mapping can contain 2 kinds of entr
     providers). Class providers return class objects themselves, rather than instances of classes.
 
     ```python
-    # NOTE: "InjectableClassType" isn't actually used, but it needs to be imported if you want
-    # your program to type-check properly.
-    from pyprovide import InjectableClass, InjectableClassType, Module, class_provider, provider
+    from typing import Type
+    from pyprovide import Module, class_provider, provider
 
     class MyModule(Module):
         @class_provider()
-        def provide_class_a(self) -> InjectableClass[ClassA]:
+        def provide_class_a(self) -> Type[ClassA]:
             return SubclassOfClassA
 
         # That class provider above is equivalent to:
@@ -167,7 +166,7 @@ instance providers and class providers). The mapping can contain 2 kinds of entr
     ```
 
     The return type annotation of a class provider is the class that it provides, wrapped in
-    `InjectableClass` (which is just an alias for `Callable[..., T]`).
+    `Type`.
 
     Also, remember that the return type annotation of the provider is used when mapping the
     provider in the registry; the provider method itself is free to return an instance of a
@@ -177,7 +176,8 @@ instance providers and class providers). The mapping can contain 2 kinds of entr
     or `@class_provider()`:
 
     ```python
-    from pyprovide import InjectableClass, InjectableClassType, Module, class_provider, provider
+    from typing import Type
+    from pyprovide import Module, class_provider, provider
 
     class MyModule(Module):
         @provider("ClassZ in color")
@@ -187,7 +187,7 @@ instance providers and class providers). The mapping can contain 2 kinds of entr
             return class_z
 
         @class_provider("ClassZ in black-and-white")
-        def provide_class_z_bw(self) -> InjectableClass[ClassZ]:
+        def provide_class_z_bw(self) -> Type[ClassZ]:
             return ClassZ
     ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Barebones dependency injection framework for Python, based on type hints
 
-Requires **Python 3.5**
+Requires **Python 3.5.2** or later
 
 ## Introduction
 

--- a/pyprovide.py
+++ b/pyprovide.py
@@ -2,7 +2,7 @@
 PyProvide - Barebones dependency injection framework for Python, based on type hints.
 For usage, see README.md.
 
-Copyright (c) 2017 Jake Hartz <jake@hartz.io>.
+Copyright (c) 2018 Jake Hartz <jake@hartz.io>.
 Licensed under the MIT License. For details, see the LICENSE file.
 """
 

--- a/pyprovide.py
+++ b/pyprovide.py
@@ -469,6 +469,7 @@ def _get_provider_return_type(provider_method: _ProviderMethod, provider_type: s
     if return_type is inspect.Signature.empty:
         raise BadProviderError("%s \"%s\" missing return type annotation" %
                                (provider_type, provider_method.__name__))
+    # TODO: Find a cleaner way to do this check
     if not isinstance(return_type, type):
         if NEW_TYPING and not isinstance(return_type, _GenericAlias):
             raise BadProviderError("%s \"%s\" return type annotation \"%s\" is not a type" %
@@ -527,6 +528,7 @@ def class_provider(provided_dependency_name: _Name = None,
             raise BadProviderError("Class provider \"%s\" %s" % (provider_method.__name__, err))
 
         return_type = _get_provider_return_type(provider_method, "Class provider")  # type: Any
+        # TODO: Find a cleaner way to do this check
         if not hasattr(return_type, "__origin__") or return_type.__origin__ is not type:
             raise BadProviderError("Class provider \"%s\"'s return type annotation \"%s\" is not "
                                    "of the form Type[...]" %


### PR DESCRIPTION
Fixes #1 

From Python 3.7 onwards, generic types created with `typing.Type` no longer are instances of `typing.Type` itself; rather, they are instances of `typing._GenericAlias`. We probably shouldn't be relying on this internal `typing` API, but this should fix it for now.

As one side effect of this, we move from using `InjectableClass` to just using `Type` directly for class providers. Functionally, this should be the same; however, it may cause issues when type-checking using "mypy" or similar.

/cc @slandau3